### PR TITLE
fix(docker): repair broken HEALTHCHECK + close e2e/doc gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 make deps              # Install mise + Node + pnpm + binary tools (act, hadolint, trivy, gitleaks, container-structure-test) from .mise.toml
 make install           # pnpm install (runs deps first)
+make check-node-alignment # Verify Node version matches across .nvmrc and Dockerfile (Renovate split-drift guard)
 make lint              # ESLint + hadolint + shell-script executable-bit guard
 make build             # TypeScript check + Vite production build (runs install first)
 make test              # Run Vitest tests
@@ -21,7 +22,7 @@ make vulncheck         # Check for known vulnerabilities in dependencies (modera
 make trivy-fs          # Trivy filesystem scan (vuln, secret, misconfig)
 make secrets           # Scan repository for leaked secrets via gitleaks
 make mermaid-lint      # Parse every ```mermaid block in README.md / CLAUDE.md via pinned mermaid-cli (script: scripts/mermaid-lint.sh)
-make static-check      # Composite quality gate (format-check, lint, vulncheck, trivy-fs, secrets, mermaid-lint)
+make static-check      # Composite quality gate (check-node-alignment, format-check, lint, vulncheck, trivy-fs, secrets, mermaid-lint)
 make ci                # Full local CI pipeline (install, static-check, coverage-check, build, deps-prune-check)
 make ci-run            # Run GitHub Actions workflow locally using act (push event)
 make ci-run-tag        # Run CI with a tag event via act (exercises docker job + DAST gate)
@@ -57,7 +58,7 @@ Test runner: `pnpm test` runs Vitest (`vitest run`). Test setup in `src/test/set
 | Layer | Target | Scope | Typical runtime |
 |-------|--------|-------|-----------------|
 | Unit | `make test` / `make coverage-check` | React components + ThemeContext via jsdom; 80% coverage gate | seconds |
-| E2E | `make e2e` | Built container through nginx: health endpoints, SPA fallback, security headers (incl. CSP/COEP/COOP/CORP), hashed bundle URL, 404 fallback | ~15s (image build + 43 curl assertions) |
+| E2E | `make e2e` | Built container through nginx: health endpoints, SPA fallback, security headers (incl. CSP/COEP/COOP/CORP), hashed bundle URL, 404 fallback | ~15s (image build + 49 curl assertions) |
 | DAST | `make dast` | ZAP baseline scan against the running container (fail-on-warn) | minutes |
 
 No integration layer — the app is a static SPA with no DB/broker/inter-service calls. `make e2e` is the first layer that exercises the full nginx surface.
@@ -106,7 +107,7 @@ GitHub Actions (`.github/workflows/ci.yml`):
 
 - Triggers: push to `main`, tags `v*`, pull requests, `workflow_call` (reusable). No trigger-level `paths-ignore` — uses a `changes` detector job (`dorny/paths-filter`) so doc-only changes skip heavy work without deadlocking Repository Rulesets that require `ci-pass`.
 - `changes` job: emits `outputs.code` (true on tag push or any non-doc file change). All heavy jobs gate on `if: needs.changes.outputs.code == 'true'`.
-- `static-check` job: checkout (`fetch-depth: 0` for gitleaks history) -> pnpm/action-setup -> setup-node (with pnpm cache) -> install -> `make static-check` (format-check + lint + vulncheck + trivy-fs + secrets + mermaid-lint, composite quality gate)
+- `static-check` job: checkout (`fetch-depth: 0` for gitleaks history) -> pnpm/action-setup -> setup-node (with pnpm cache) -> install -> `make static-check` (check-node-alignment + format-check + lint + vulncheck + trivy-fs + secrets + mermaid-lint, composite quality gate)
 - `build` job: install -> `make build` (runs after `static-check`)
 - `test` job: install -> `make coverage-check` (runs after `static-check`, parallel with `build`)
 - `e2e` job: install -> `make e2e` (curl-based assertions against built nginx container)

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,10 @@ USER 101
 COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder ./app/dist /usr/share/nginx/html
 EXPOSE 8080
+# Probe 127.0.0.1, not localhost: the Alpine image's /etc/hosts lists `::1 localhost`
+# first, so busybox wget resolves localhost to IPv6 and connects to [::1]:8080, but
+# nginx `listen 8080;` binds IPv4 (0.0.0.0) only → Connection refused → perpetual
+# `unhealthy`. CI never caught this because e2e/smoke hit the host-published port.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget -qO- http://localhost:8080/internal/isalive || exit 1
+  CMD wget -qO- http://127.0.0.1:8080/internal/isalive || exit 1
 CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # viteapp — Hardened Vite + React SPA Pipeline
 
-A Vite + React + TypeScript SPA shipped as a hardened multi-arch (`amd64`/`arm64`) nginx container, signed with cosign keyless OIDC on tag push to GHCR. The CI pipeline gates publish on Trivy filesystem + image scans (CRITICAL/HIGH blocking), container-structure-test, ZAP baseline DAST in fail-on-warn mode, 80 % Vitest coverage, and 43 curl-based e2e assertions. nginx serves the SPA under strict CSP/COEP/COOP/CORP with immutable cache for hashed `/assets/*` and `no-cache` on the index + SPA fallback.
+A Vite + React + TypeScript SPA shipped as a hardened multi-arch (`amd64`/`arm64`) nginx container, signed with cosign keyless OIDC on tag push to GHCR. The CI pipeline gates publish on Trivy filesystem + image scans (CRITICAL/HIGH blocking), container-structure-test, ZAP baseline DAST in fail-on-warn mode, 80 % Vitest coverage, and 49 curl-based e2e assertions. nginx serves the SPA under strict CSP/COEP/COOP/CORP with immutable cache for hashed `/assets/*` and `no-cache` on the index + SPA fallback.
 
 ```mermaid
 C4Context
@@ -38,7 +38,7 @@ C4Context
 ## Quick Start
 
 ```bash
-make deps      # install system dependencies (node, pnpm, docker, git)
+make deps      # install mise + Node + pnpm + binary tools (act, hadolint, trivy, gitleaks, container-structure-test)
 make build     # type-check and build for production
 make test      # run Vitest tests
 make run       # start Vite dev server with HMR
@@ -132,11 +132,12 @@ Run `make help` to see all available targets.
 
 | Target              | Description                                                       |
 | ------------------- | ----------------------------------------------------------------- |
+| `make check-node-alignment` | Verify the Node version matches across `.nvmrc` and Dockerfile (Renovate split-drift guard) |
 | `make lint`         | Run ESLint and hadolint on source files                           |
 | `make vulncheck`    | Check for known vulnerabilities in dependencies (moderate+)       |
 | `make trivy-fs`     | Trivy filesystem scan (vuln, secret, misconfig)                   |
 | `make secrets`      | Scan repository for leaked secrets via gitleaks                   |
-| `make static-check` | Composite quality gate (format-check, lint, vulncheck, trivy-fs, secrets, mermaid-lint) |
+| `make static-check` | Composite quality gate (check-node-alignment, format-check, lint, vulncheck, trivy-fs, secrets, mermaid-lint) |
 | `make mermaid-lint` | Parse every ` ```mermaid ` fenced block via pinned `minlag/mermaid-cli`   |
 | `make format`       | Format source files with Prettier                                 |
 | `make format-check` | Check formatting without writing                                  |
@@ -189,7 +190,7 @@ GitHub Actions runs on every push to `main`, tags `v*`, pull requests, and `work
 | Job              | Triggers       | Steps                                                                                          |
 | ---------------- | -------------- | ---------------------------------------------------------------------------------------------- |
 | **changes**      | push, PR, tags | `dorny/paths-filter` — sets `outputs.code` true when non-doc files change. Tag push always true |
-| **static-check** | code change    | Install, `make static-check` (format-check, lint, vulncheck, trivy-fs, secrets, mermaid-lint)  |
+| **static-check** | code change    | Install, `make static-check` (check-node-alignment, format-check, lint, vulncheck, trivy-fs, secrets, mermaid-lint)  |
 | **build**        | code change    | Install, Build (after static-check)                                                            |
 | **test**         | code change    | Install, `make coverage-check` (Vitest + 80% thresholds, after static-check)                   |
 | **e2e**          | code change    | Build image, `make e2e` — curl-based tests against nginx (health, SPA fallback, headers, hashed bundle, 404 fallback) |

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -37,7 +37,7 @@ assert_body_contains() {
 assert_header() {
   local path="$1" header="$2" expected_regex="$3"
   local value
-  value=$(curl -sI "$BASE$path" | awk -v h="$header" 'BEGIN{IGNORECASE=1} tolower($1) == tolower(h":") { sub(/^[^:]+:[ \t]*/, ""); sub(/\r$/, ""); print; exit }')
+  value=$(curl -sI "$BASE$path" | awk -v h="$header" 'tolower($1) == tolower(h":") { sub(/^[^:]+:[ \t]*/, ""); sub(/\r$/, ""); print; exit }')
   if [[ -n "$value" ]] && echo "$value" | grep -Eq "$expected_regex"; then
     log_pass "$path $header: $value"
   else
@@ -47,7 +47,7 @@ assert_header() {
 
 assert_header_absent() {
   local path="$1" header="$2"
-  if curl -sI "$BASE$path" | awk -v h="$header" 'BEGIN{IGNORECASE=1} tolower($1) == tolower(h":") { found=1 } END { exit !found }'; then
+  if curl -sI "$BASE$path" | awk -v h="$header" 'tolower($1) == tolower(h":") { found=1 } END { exit !found }'; then
     log_fail "$path should not expose header '$header'"
   else
     log_pass "$path does not expose '$header'"
@@ -59,14 +59,22 @@ echo "=== E2E tests against $BASE ==="
 # Health endpoints
 assert_status GET /internal/isalive 200
 assert_status GET /internal/isready 200
+# Health endpoints declare text/plain Content-Type and no-store caching (a probe
+# must never be cached, and the body must not be sniffed as HTML).
+assert_header /internal/isalive Content-Type 'text/plain'
+assert_header /internal/isready Content-Type 'text/plain'
+assert_header /internal/isalive Cache-Control 'no-store'
+assert_header /internal/isready Cache-Control 'no-store'
 
 # SPA fallback: unknown deep links must return index.html (200) so client-side routing works.
 assert_status GET /some/spa/route 200
 assert_body_contains /some/spa/route '<div id="root"'
 
-# Asset serving: index.html itself.
+# Asset serving: index.html itself. The index must NOT be cached (no-store) so a
+# deploy of a new hashed bundle is picked up immediately rather than served stale.
 assert_status GET / 200
 assert_body_contains / '<div id="root"'
+assert_header / Cache-Control 'no-store'
 
 # Hashed bundle URL: discover the JS bundle from index.html and verify it serves correctly.
 # Catches Rolldown/terser regressions producing 404 on the bundle.
@@ -74,6 +82,9 @@ bundle_path=$(curl -sf "$BASE/" | grep -oE '/assets/[^"]+\.js' | head -1)
 if [[ -n "$bundle_path" ]]; then
   assert_status GET "$bundle_path" 200
   assert_header "$bundle_path" Content-Type 'javascript'
+  # Hashed assets are immutable + long-lived; a regression dropping this header
+  # defeats the content-hash caching strategy.
+  assert_header "$bundle_path" Cache-Control 'immutable'
 else
   log_fail "GET / did not reference any /assets/*.js bundle"
 fi


### PR DESCRIPTION
Consolidated `/project-review` + `/test-coverage-analysis` fixes. All verified locally (`make ci` green, `make e2e` 49/49, rebuilt image reaches `healthy`).

## HIGH — broken runtime HEALTHCHECK (Docker image pipeline)
`HEALTHCHECK wget http://localhost:8080/...` resolved `localhost` to IPv6 `[::1]` (Alpine `/etc/hosts` lists `::1 localhost` first), but `nginx listen 8080;` binds IPv4 (`0.0.0.0`) only → **Connection refused → container reported `unhealthy` forever**. Invisible to CI because e2e/smoke hit the host-published port (IPv4). Any orchestrator using the Docker healthcheck (`docker run` health-gating, compose `condition: service_healthy`) saw the image as perpetually unhealthy.

Fix: probe `127.0.0.1` (deterministic IPv4). Verified the rebuilt image now reaches `healthy` at ~10s (previously stuck `starting`→`unhealthy`).

## MEDIUM/LOW — e2e coverage (`/test-coverage-analysis`)
- **Assert the nginx `Cache-Control` contract** (previously unasserted): `immutable` on hashed `/assets/*`, `no-store` on `/` and both health endpoints. A regression dropping `immutable` (cache-bust) or `no-store` on `/` (stale SPA after deploy) previously shipped green.
- **Assert health-endpoint `Content-Type: text/plain`.**
- **Remove the gawk-only `BEGIN{IGNORECASE=1}` no-op** from the awk header matchers (the `tolower()` comparison already handles case; the clause silently disables under CI's mawk — a latent trap). e2e now **49/49** (was 43).

## Docs (project-review README + CLAUDE.md)
- Propagate `make check-node-alignment` (the first `static-check` prerequisite) into README + CLAUDE.md command tables and every `static-check` description.
- Fix the `make deps` Quick-Start comment (installs mise + Node + pnpm + binary tools, not docker/git).
- Bump the e2e assertion count 43 → 49.

Infra (Makefile, CI workflows, renovate.json, architecture diagrams) reviewed **CLEAN** — no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)