### PR TITLE
test(e2e): Playwright Chromium browser smoke against the built container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,46 @@ jobs:
         # download-artifact fallback is needed for act-runner parity.
         run: make e2e
 
+  e2e-browser:
+    needs: [build, test]
+    # Skipped under act: the Playwright browser download + Docker-in-Docker is
+    # heavy and `actions/upload-artifact@v7` fails on act's v4-protocol server.
+    # `make ci-run` does NOT exercise this job — run `make e2e-browser` locally.
+    if: ${{ vars.ACT != 'true' }}
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+          cache-dependency-path: "**/pnpm-lock.yaml"
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Browser e2e (Playwright)
+        run: make e2e-browser
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   docker:
     needs: [build, test]
     timeout-minutes: 30
@@ -374,7 +414,7 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [changes, static-check, build, test, e2e, docker, dast]
+    needs: [changes, static-check, build, test, e2e, e2e-browser, docker, dast]
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 coverage
 zap-output
+playwright-report
+test-results
+/playwright/.cache
 *.local
 
 # Editor directories and files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ make image-run         # Run Docker container on port 8080
 make image-stop        # Stop the production Docker container
 make image-cst         # Container-structure-test against the built image (USER 101, EXPOSE 8080, file presence, nginx -t)
 make e2e               # E2E tests against the built container (health, SPA fallback, security headers, hashed bundle, 404 fallback)
+make e2e-browser       # Playwright Chromium smoke against the built container (counter, theme toggle + persistence, CSP)
 make dast              # ZAP baseline DAST scan against the built image (fail-on-warn; .zap/baseline-rules.tsv ignores informational 10049/10109)
 make release           # Create and push a new tag (interactive prompt for vX.Y.Z)
 make deps-update       # Update dependencies to latest compatible versions (pnpm update)
@@ -59,9 +60,10 @@ Test runner: `pnpm test` runs Vitest (`vitest run`). Test setup in `src/test/set
 |-------|--------|-------|-----------------|
 | Unit | `make test` / `make coverage-check` | React components + ThemeProvider/useTheme via jsdom; 80% coverage gate | seconds |
 | E2E | `make e2e` | Built container through nginx: health endpoints, SPA fallback, security headers (incl. CSP/COEP/COOP/CORP), hashed bundle URL, 404 fallback | ~15s (image build + 49 curl assertions) |
+| Browser E2E | `make e2e-browser` | Playwright Chromium against the built nginx container: app boot, counter, light/dark theme toggle + persistence, console CSP-violation check | ~30s (image build + Chromium) |
 | DAST | `make dast` | ZAP baseline scan against the running container (fail-on-warn) | minutes |
 
-No integration layer — the app is a static SPA with no DB/broker/inter-service calls. `make e2e` is the first layer that exercises the full nginx surface.
+No integration layer — the app is a static SPA with no DB/broker/inter-service calls. `make e2e` (curl) exercises the full nginx surface; `make e2e-browser` then drives the built bundle in a real browser (the JS behavior — theme toggle, counter, CSP enforcement — that curl and jsdom cannot reach).
 
 ## Architecture
 
@@ -74,7 +76,7 @@ React 19 SPA built with Vite 8 and TypeScript (strict mode).
 
 ### Notable design decisions
 
-- **Playwright deferred** — current curl-based e2e covers nginx surface and hashed bundle; adding a Playwright smoke against the built bundle would catch Rolldown/terser/chunking regressions jsdom cannot see. Low priority; counter logic is already unit-tested.
+- **Playwright browser smoke** (`make e2e-browser`, CI `e2e-browser` job) — a Chromium Playwright spec (`e2e/browser/app.spec.ts`, config `playwright.config.ts`) drives the built bundle inside the production nginx container, under the real CSP: app boot, counter increment, the light/dark theme toggle (`data-theme` flip + `localStorage` persistence across reload), and a console CSP-violation assertion. Catches Rolldown/terser/chunking and inline-style/CSP regressions that jsdom (source, not bundle) and curl (no JS) cannot. Skipped under act (browser download + DinD + `upload-artifact@v7`), so `make ci-run` does NOT exercise it — run `make e2e-browser` locally before pushing UI/bundle changes.
 - **No CSP `'unsafe-inline'`** — all styling is className + CSS-custom-property based (never inline `style`), so `script-src 'self'; style-src 'self'` (no `unsafe-inline`) is enforceable. The light/dark theme switches by toggling a `data-theme` attribute on `<html>` (which selects CSS variables defined in `src/index.css`) rather than applying inline styles — that is why the theme is CSP-safe. The `ThemeContext` default carries no colors, only the theme name + setters.
 
 ## Build & Bundle Config
@@ -111,9 +113,10 @@ GitHub Actions (`.github/workflows/ci.yml`):
 - `build` job: install -> `make build` (runs after `static-check`)
 - `test` job: install -> `make coverage-check` (runs after `static-check`, parallel with `build`)
 - `e2e` job: install -> `make e2e` (curl-based assertions against built nginx container)
+- `e2e-browser` job: install -> `pnpm exec playwright install --with-deps chromium` -> `make e2e-browser` (Playwright Chromium against the built container; uploads the HTML report as an artifact). **Skipped under act** (`if: ${{ vars.ACT != 'true' }}`) because the browser download + Docker-in-Docker + `actions/upload-artifact@v7` don't work under act — `make ci-run` does NOT exercise it; run `make e2e-browser` locally before pushing UI/bundle changes.
 - `docker` job: QEMU -> Buildx -> meta -> build-for-scan (single-arch, `load: true`) -> Trivy image scan (CRITICAL/HIGH blocking, `ignore-unfixed: true`) -> container-structure-test -> smoke test (`curl /internal/isalive`) -> multi-arch build (runs every push so arm64 cross-compile regressions surface pre-tag) -> tag-gated push + cosign keyless OIDC signing. `provenance: false` + `sbom: false` on the publish step (buildkit attestations break the GHCR "OS / Arch" UI; cosign keyless signing provides supply-chain verification).
 - `dast` job (parallel with `docker`): build single-arch image -> start -> ZAP baseline (fail-on-warn; `.zap/baseline-rules.tsv` IGNOREs ZAP rules 10049 (cache-storability informational) and 10109 (Modern Web Application informational) with rationale) -> upload report. **Job is skipped under act** (`if: ${{ vars.ACT != 'true' }}`) because ZAP requires Docker-in-Docker and `actions/upload-artifact@v7` fails under act's v4-protocol artifact server — `make ci-run` does NOT exercise this job. Failure modes that can slip through `make ci-run` and only surface on real GitHub Actions: ZAP rule additions/removals (run `make dast` locally before push), nginx response-header regressions that ZAP catches but e2e doesn't, and any `actions/upload-artifact@v7+` migration breakage. Mitigation: every nginx.conf edit MUST be followed by `make dast` locally before push.
-- `ci-pass` job (aggregation gate, `if: always()`, `needs: [changes, static-check, build, test, e2e, docker, dast]`): single check suitable for branch protection.
+- `ci-pass` job (aggregation gate, `if: always()`, `needs: [changes, static-check, build, test, e2e, e2e-browser, docker, dast]`): single check suitable for branch protection.
 - Docker images pushed to `ghcr.io` as multi-arch (`amd64` + `arm64`) with GHA build cache.
 - Permissions: `contents: read` at workflow level; `packages: write` + `id-token: write` (cosign OIDC) on docker job only; `pull-requests: read` on changes job.
 

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ deps:
 
 #clean: @ Remove node_modules/, dist/, coverage/, and zap-output/
 clean:
-	@rm -rf node_modules/ dist/ coverage/ zap-output/
+	@rm -rf node_modules/ dist/ coverage/ zap-output/ playwright-report/ test-results/
 
 #install: @ Install project dependencies via pnpm
 install: deps
@@ -187,6 +187,21 @@ e2e: image-build
 		docker rm -f viteapp-test >/dev/null; \
 		exit $$EXIT
 
+#e2e-browser: @ Playwright Chromium smoke against the built container (counter, theme toggle, CSP)
+e2e-browser: install image-build
+	@npx playwright install chromium
+	@docker rm -f viteapp-pw 2>/dev/null || true
+	@docker run -d --name=viteapp-pw -p 8080:8080 $(APP_NAME):$(CURRENTTAG) >/dev/null
+	@echo "Waiting for nginx to become healthy..."
+	@end=$$(( $$(date +%s) + 30 )); \
+		while [ $$(date +%s) -lt $$end ]; do \
+			curl -fsS http://localhost:8080/internal/isalive >/dev/null 2>&1 && break; \
+			sleep 1; \
+		done
+	@BASE_URL=http://localhost:8080 npx playwright test; EXIT=$$?; \
+		docker rm -f viteapp-pw >/dev/null; \
+		exit $$EXIT
+
 #dast: @ ZAP baseline DAST scan against the built image (mirrors CI gate, fail-on-warn)
 dast: image-build
 	@docker rm -f viteapp-test 2>/dev/null || true
@@ -267,5 +282,5 @@ renovate-validate:
 .PHONY: help deps clean install lint build test coverage-check vulncheck \
 	trivy-fs secrets check-node-alignment static-check deps-update deps-prune \
 	deps-prune-check run format format-check ci image-build image-run \
-	image-stop image-cst e2e dast release ci-run ci-run-tag renovate \
+	image-stop image-cst e2e e2e-browser dast release ci-run ci-run-tag renovate \
 	renovate-validate mermaid-lint

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # viteapp — Hardened Vite + React SPA Pipeline
 
-A Vite + React + TypeScript SPA shipped as a hardened multi-arch (`amd64`/`arm64`) nginx container, signed with cosign keyless OIDC on tag push to GHCR. The CI pipeline gates publish on Trivy filesystem + image scans (CRITICAL/HIGH blocking), container-structure-test, ZAP baseline DAST in fail-on-warn mode, 80 % Vitest coverage, and 49 curl-based e2e assertions. nginx serves the SPA under strict CSP/COEP/COOP/CORP with immutable cache for hashed `/assets/*` and `no-cache` on the index + SPA fallback.
+A Vite + React + TypeScript SPA shipped as a hardened multi-arch (`amd64`/`arm64`) nginx container, signed with cosign keyless OIDC on tag push to GHCR. The CI pipeline gates publish on Trivy filesystem + image scans (CRITICAL/HIGH blocking), container-structure-test, ZAP baseline DAST in fail-on-warn mode, 80 % Vitest coverage, 49 curl-based e2e assertions, and a Playwright Chromium browser smoke. nginx serves the SPA under strict CSP/COEP/COOP/CORP with immutable cache for hashed `/assets/*` and `no-cache` on the index + SPA fallback.
 
 ```mermaid
 C4Context
@@ -126,6 +126,7 @@ Run `make help` to see all available targets.
 | `make test`           | Run Vitest unit tests (fast, jsdom)                                         |
 | `make coverage-check` | Run Vitest with coverage thresholds (CI gate, 80%)                          |
 | `make e2e`            | End-to-end tests against the built container (health, SPA fallback, headers) |
+| `make e2e-browser`    | Playwright Chromium smoke against the built container (counter, theme toggle, CSP) |
 | `make dast`           | ZAP baseline DAST scan against the built image (mirrors CI gate)            |
 
 ### Code Quality
@@ -194,6 +195,7 @@ GitHub Actions runs on every push to `main`, tags `v*`, pull requests, and `work
 | **build**        | code change    | Install, Build (after static-check)                                                            |
 | **test**         | code change    | Install, `make coverage-check` (Vitest + 80% thresholds, after static-check)                   |
 | **e2e**          | code change    | Build image, `make e2e` — curl-based tests against nginx (health, SPA fallback, headers, hashed bundle, 404 fallback) |
+| **e2e-browser**  | code change    | Build image, `make e2e-browser` — Playwright Chromium against the built container (boot, counter, theme toggle + persistence, CSP). Skipped under act |
 | **docker**       | code change    | Build-for-scan → Trivy → container-structure-test → Smoke → Multi-arch build (every push) → (on `v*` tags only) Push + Cosign signing |
 | **dast**         | code change    | Build → start → ZAP baseline (fail-on-warn; `.zap/baseline-rules.tsv` ignores informational rules) → upload report |
 | **ci-pass**      | all            | Aggregation gate (`if: always()`) — single required check for branch protection                 |

--- a/e2e/browser/app.spec.ts
+++ b/e2e/browser/app.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "@playwright/test";
+
+const STORAGE_KEY = "viteapp-theme";
+
+// These run against the BUILT bundle served by the production nginx container
+// (started by `make e2e-browser`), so they exercise what jsdom + curl cannot:
+// the real Rolldown/terser output executing in a browser, under the production
+// CSP that nginx emits.
+
+test.describe("viteapp built bundle", () => {
+  test("boots and the counter increments", async ({ page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: "Vite + React" }),
+    ).toBeVisible();
+
+    const counter = page.getByRole("button", { name: /count is 0/i });
+    await expect(counter).toBeVisible();
+    await counter.click();
+    await expect(
+      page.getByRole("button", { name: /count is 1/i }),
+    ).toBeVisible();
+  });
+
+  test("theme toggle flips data-theme, button label, and persists across reload", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const html = page.locator("html");
+    const toggle = page.getByTestId("theme-toggle");
+
+    await expect(html).toHaveAttribute("data-theme", /^(light|dark)$/);
+    const initial = await html.getAttribute("data-theme");
+    const flipped = initial === "dark" ? "light" : "dark";
+    await expect(toggle).toHaveText(
+      initial === "dark" ? /Light mode/ : /Dark mode/,
+    );
+
+    await toggle.click();
+    await expect(html).toHaveAttribute("data-theme", flipped);
+    await expect(toggle).toHaveText(
+      flipped === "dark" ? /Light mode/ : /Dark mode/,
+    );
+
+    // The choice is persisted and survives a full reload.
+    await page.reload();
+    await expect(html).toHaveAttribute("data-theme", flipped);
+    expect(
+      await page.evaluate((k) => localStorage.getItem(k), STORAGE_KEY),
+    ).toBe(flipped);
+  });
+
+  test("no CSP violations or uncaught errors on load + toggle", async ({
+    page,
+  }) => {
+    // The theme is applied via `data-theme` + CSS variables (no inline styles),
+    // so the strict CSP nginx serves (`style-src 'self'`, no `unsafe-inline`)
+    // must not fire. A regression that reintroduced inline styles would surface
+    // here as a "Refused to apply inline style" CSP console error.
+    const cspViolations: string[] = [];
+    const pageErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (
+        msg.type() === "error" &&
+        /content security policy|refused to/i.test(msg.text())
+      ) {
+        cspViolations.push(msg.text());
+      }
+    });
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    await page.goto("/");
+    await page.getByTestId("theme-toggle").click();
+
+    expect(cspViolations, cspViolations.join("\n")).toEqual([]);
+    expect(pageErrors, pageErrors.join("\n")).toEqual([]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prettier": "prettier --ignore-path .gitignore --write 'src/**/*.{ts,tsx,js,jsx}'",
     "prettier:diff": "prettier --check 'src/**/*.{ts,tsx,js,jsx}'",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "lint": "eslint . --max-warnings 0"
   },
   "dependencies": {
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
+    "@playwright/test": "1.61.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// The nginx container under test is started by `make e2e-browser` (mirroring
+// `make e2e`/`make dast`), so Playwright does NOT manage a webServer — it just
+// drives whatever BASE_URL points at. Default matches the Makefile's host port.
+const baseURL = process.env.BASE_URL ?? "http://localhost:8080";
+
+export default defineConfig({
+  testDir: "./e2e/browser",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["list"]],
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@eslint/js':
         specifier: 10.0.1
         version: 10.0.1(eslint@10.5.0)
+      '@playwright/test':
+        specifier: 1.61.1
+        version: 1.61.1
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
@@ -486,6 +489,11 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -994,6 +1002,11 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1270,6 +1283,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -1933,6 +1956,10 @@ snapshots:
 
   '@oxc-project/types@0.133.0': {}
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -2453,6 +2480,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2683,6 +2713,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.15:
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     css: true,
+    // Scope Vitest to src/ only. Without this, Vitest's default discovery picks
+    // up e2e/browser/*.spec.ts (the Playwright specs) and fails with
+    // "Playwright Test did not expect test.describe() to be called here".
+    // Playwright owns e2e/browser/** via playwright.config.ts.
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html", "lcov"],


### PR DESCRIPTION
Closes the **"Playwright deferred"** gap (and follows the theme PR #313 — this is what verifies the new toggle in a real browser).

## What it covers
A single Chromium spec (`e2e/browser/app.spec.ts`) drives the **production bundle inside the nginx container**, under the **real CSP** — the JS behavior `jsdom` (source, not bundle) and `curl` (no JS) cannot reach:
- **App boot + counter increment** — catches Rolldown/terser/chunking regressions that yield a 200 but a broken runtime bundle.
- **Theme toggle** — `data-theme` flip, button label, and `localStorage` persistence across a full reload.
- **CSP-violation assertion** — fails if inline styles are reintroduced (the strict `style-src 'self'` nginx serves would block them and log a console error). This is the real-browser proof of the theme's CSP-safety.

## Wiring
- `@playwright/test` 1.61.1 (devDep, Renovate dev-dependencies group) + `playwright.config.ts` (Chromium, `BASE_URL`, **no** `webServer` — the Makefile owns the container, mirroring `make e2e`/`make dast`).
- **`make e2e-browser`**: build image → run container → wait healthy → `playwright test` → cleanup.
- CI **`e2e-browser`** job: `needs: [build, test]`, **skipped under act** (`if: vars.ACT != 'true'`, like `dast`), installs `--with-deps chromium`, uploads the HTML report; added to the `ci-pass` `needs` list.
- `.gitignore` + `clean` updated for `playwright-report/` / `test-results/`.
- README + CLAUDE.md updated; the "Playwright deferred" note replaced with the implemented job.

## Verified locally
- `make e2e-browser` → **3/3 passed** against the built container.
- `make ci` green; `make help` lists the target; `actionlint` adds no new findings (the 3 SC2086 infos are pre-existing `${{ }}` false-positives).

> `make ci-run` does NOT exercise this job (skipped under act) — run `make e2e-browser` locally before pushing UI/bundle changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)