### PR TITLE
fix(deps): declare esbuild as a direct devDependency (deterministic build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.3",
     "@vitest/coverage-v8": "4.1.9",
+    "esbuild": "0.27.4",
     "eslint": "10.5.0",
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-react-refresh": "0.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.9
         version: 4.1.9(vitest@4.1.9)
+      esbuild:
+        specifier: 0.27.4
+        version: 0.27.4
       eslint:
         specifier: 10.5.0
         version: 10.5.0
@@ -2382,7 +2385,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.4
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
-    optional: true
 
   escalade@3.2.0: {}
 


### PR DESCRIPTION
## Problem

The `build` CI job failed (run [28341536944](https://github.com/AndriyKalashnykov/viteapp/actions/runs/28341536944), `renovate/lock-file-maintenance`):

```
[plugin vite:css-post] Error: Cannot find package 'esbuild'
imported from .../vite@8.1.0/.../node.js
make: *** [Makefile:91: build] Error 1
```

## Root cause

`vite.config.ts` sets `build.cssMinify: "esbuild"`, so the production build **directly requires `esbuild`**. But `esbuild` was only an **optional dependency of Vite 8** (rolldown-vite) — never declared by this project:

```
vite@8.1.0(...)(esbuild@0.27.4)(...):
    optionalDependencies:
      esbuild: 0.27.4
```

Whether pnpm wires that optional `esbuild` into Vite is **non-deterministic across lockfile regenerations**. Renovate's `lockFileMaintenance` regenerated a lockfile where `esbuild` wasn't wired → `vite:css-post` couldn't resolve it → build broke. This is the version-discipline class *"a lockfile regeneration can silently drop a transitive edge that supplied a directly-used API."*

## Fix

Declare `esbuild` as an explicit **direct devDependency** (Renovate-tracked), exactly mirroring how **`terser` is already declared** for `build.minify: "terser"`. `esbuild` is now always installed and always satisfies Vite's optional `esbuild` slot, so any future full re-resolve wires it deterministically.

Diff is minimal: `package.json` gains one line; `pnpm-lock.yaml` gains the importer entry and `esbuild` loses `optional: true`.

## Verification

- **Reproduced determinism:** wiped `pnpm-lock.yaml` + `node_modules`, ran a full fresh resolve (= `lockFileMaintenance`) → `esbuild` wired into Vite, build green — every time.
- Gates (each rc=0): `build`, `coverage-check`, `test`, `lint`, `format-check`, `vulncheck`, `deps-prune-check`.
- `depcheck` does **not** flag `esbuild` (recognized like `terser`).

## Note on the other recent red run

`renovate/major-github-actions` run [28258422739](https://github.com/AndriyKalashnykov/viteapp/actions/runs/28258422739) (`e2e-browser`) failed on a Docker Hub registry timeout (`registry-1.docker.io ... Client.Timeout exceeded`) — pure infra transient; the same branch passed before and after and merged green. No code fix applies.