### PR TITLE
ci(lint): guard that config-referenced minifiers stay declared deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,10 @@ secrets: deps
 mermaid-lint:
 	@./scripts/mermaid-lint.sh $(MERMAID_CLI_VERSION)
 
+#check-minifier-deps: @ Verify every minifier named in vite.config.ts is a declared dependency (guards the esbuild/terser optional-peer trap)
+check-minifier-deps:
+	@node scripts/check-minifier-deps.mjs
+
 #check-node-alignment: @ Verify the Node version matches across .nvmrc and Dockerfile (fails fast on Renovate split drift)
 check-node-alignment:
 	@nvmrc=$$(tr -d '[:space:]' < .nvmrc); \
@@ -125,8 +129,8 @@ check-node-alignment:
 			exit 1; \
 		fi
 
-#static-check: @ Composite quality gate (check-node-alignment, format-check, lint, vulncheck, trivy-fs, secrets, mermaid-lint)
-static-check: check-node-alignment format-check lint vulncheck trivy-fs secrets mermaid-lint
+#static-check: @ Composite quality gate (check-node-alignment, check-minifier-deps, format-check, lint, vulncheck, trivy-fs, secrets, mermaid-lint)
+static-check: check-node-alignment check-minifier-deps format-check lint vulncheck trivy-fs secrets mermaid-lint
 	@echo "static-check passed."
 
 #deps-update: @ Update dependencies to latest compatible versions (pnpm update)
@@ -296,7 +300,7 @@ renovate-validate:
 	@npx --yes --package renovate@$(RENOVATE_VERSION) -- renovate-config-validator --strict renovate.json
 
 .PHONY: help deps clean install lint build test coverage-check vulncheck \
-	trivy-fs secrets check-node-alignment static-check deps-update deps-prune \
+	trivy-fs secrets check-node-alignment check-minifier-deps static-check deps-update deps-prune \
 	deps-prune-check run format format-check ci image-build image-run \
 	image-stop image-cst e2e e2e-browser lighthouse dast release ci-run ci-run-tag renovate \
 	renovate-validate mermaid-lint

--- a/scripts/check-minifier-deps.mjs
+++ b/scripts/check-minifier-deps.mjs
@@ -1,0 +1,59 @@
+// Guard: every minifier named in vite.config.ts (build.minify / build.cssMinify)
+// must be a declared dependency in package.json.
+//
+// terser, esbuild and lightningcss are Vite *optional* peers used only as config
+// STRINGS (never `import`ed). Because they're never imported, depcheck
+// (`make deps-prune-check`) does NOT flag their removal, and a frozen-lockfile
+// install keeps passing (the committed lockfile still contains them). But a full
+// re-resolve (Renovate `lockFileMaintenance`) can drop the optional-peer wiring,
+// and the build then fails non-deterministically with
+// `[plugin vite:css-post] Error: Cannot find package '<minifier>'`.
+//
+// Declaring each minifier as a direct dependency makes the wiring deterministic.
+// This gate fails the moment a config-referenced minifier is no longer declared,
+// so the silent-removal hole is closed at lint time instead of on the next
+// weekly lockfile maintenance. See viteapp PR #326.
+import { readFileSync } from "node:fs";
+
+// The minifiers Vite accepts as `minify` / `cssMinify` values that resolve to a
+// real npm package (i.e. an optional peer that must be installed). Boolean values
+// (`true`/`false`) need no package and are ignored.
+const MINIFIER_PACKAGES = new Set(["terser", "esbuild", "lightningcss"]);
+
+const root = new URL("../", import.meta.url);
+const config = readFileSync(new URL("vite.config.ts", root), "utf8");
+const pkg = JSON.parse(readFileSync(new URL("package.json", root), "utf8"));
+
+const declared = new Set([
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.devDependencies ?? {}),
+]);
+
+// Extract the quoted string value of every `minify:` / `cssMinify:` key.
+const used = new Set();
+for (const m of config.matchAll(/\b(?:css)?[Mm]inify\s*:\s*["']([^"']+)["']/g)) {
+  used.add(m[1]);
+}
+
+const relevant = [...used].filter((v) => MINIFIER_PACKAGES.has(v));
+const missing = relevant.filter((v) => !declared.has(v));
+
+if (missing.length > 0) {
+  console.error(
+    `✗ minifier(s) referenced in vite.config.ts but NOT declared in package.json: ${missing.join(", ")}`,
+  );
+  console.error(
+    "  These are Vite optional-peer minifiers (used as config strings, never imported);",
+  );
+  console.error(
+    "  depcheck won't flag them and frozen-lockfile CI still passes, but the build breaks",
+  );
+  console.error(
+    "  non-deterministically on the next full lockfile re-resolve. Add each to devDependencies.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✓ minifier deps declared: ${relevant.length ? relevant.join(", ") : "(none referenced)"}`,
+);


### PR DESCRIPTION
## Why

Follow-up to #326. That PR fixed the root cause (declared `esbuild`), but the declaration was **unguarded**: `terser`/`esbuild` are Vite optional-peer minifiers used only as config strings in `vite.config.ts` (never `import`ed), so:

- `depcheck` (`make deps-prune-check`) does **not** flag their removal, and
- a frozen-lockfile install keeps passing (the committed lockfile still contains them).

So a future "cleanup" could drop the declaration, CI would stay green, and the build would break **non-deterministically** on the next Renovate `lockFileMaintenance` — the exact failure #326 fixed.

## What

Adds `make check-minifier-deps` (a ~50-line `scripts/check-minifier-deps.mjs`) to the `static-check` composite gate. It extracts every `minify:` / `cssMinify:` value from `vite.config.ts` and asserts each minifier package (`terser`, `esbuild`, `lightningcss`) is declared in `package.json`. Mirrors the existing `check-node-alignment` sibling guard.

## Verified (demonstrated RED)

```
$ make check-minifier-deps                 # declared
✓ minifier deps declared: terser, esbuild   → rc=0

$ # remove esbuild from devDependencies
$ make check-minifier-deps
✗ minifier(s) referenced in vite.config.ts but NOT declared in package.json: esbuild
make: *** [check-minifier-deps] Error 1     → rc=2
```

`make lint` / `make format-check` green. The `.mjs` is invoked via `node` (no executable bit needed, so the shell-script +x guard is unaffected).