### PR TITLE
chore(renovate): track the C4-PlantUML !include version; refresh review date

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ Cleanup (`.github/workflows/cleanup-runs.yml`):
 
 ## Upgrade Backlog
 
-Last reviewed: 2026-06-24 (`/upgrade-analysis` + `/renovate` pass)
+Last reviewed: 2026-06-30 (`/ship-it`: `/upgrade-analysis` + `/renovate` pass)
 
 - [ ] **`undici` override (`pnpm-workspace.yaml`) + `<8` cap (`renovate.json`)** — `undici@>=7.0.0 <7.28.0` is overridden to `^7.28.0` to clear the TLS cert-validation-bypass / WebSocket-DoS / cross-origin-routing advisories (transitive via `@vitest/coverage-v8 > vitest > jsdom > undici`). A Renovate `allowedVersions: <8` cap holds it on the 7.x line because jsdom 29.1.1 hard-requires `undici/lib/handler/wrap-handler.js`, which undici v8 removed (verified: PR #303 broke the vitest/jsdom runtime and was closed). Remove both the override and the `<8` cap when jsdom ships a release that consumes `undici >= 8` directly.
 - [ ] **`brace-expansion` override (`pnpm-workspace.yaml`)** — `brace-expansion@>=5.0.0 <5.0.6` is overridden to `^5.0.6` to clear the ReDoS advisory (transitive via eslint). Remove when eslint pulls `brace-expansion >= 5.0.6` directly.

--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,14 @@
       "matchStrings": ["Node\\.js (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
       "currentValueTemplate": "{{{currentValue}}}-alpine",
       "autoReplaceStringTemplate": "{{{newVersion}}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the C4-PlantUML !include version pinned in docs/diagrams/*.puml. The pinned `v<ver>` in the raw.githubusercontent.com URL is a version literal no built-in manager covers, so without this it silently rots while every other tool pin in the repo is Renovate-tracked. datasource=github-tags on plantuml-stdlib/C4-PlantUML; the matched tag is written back into the URL. A bump changes the .puml source, which the CI `code` paths-filter routes to static-check → diagrams-check (the render drift gate), so a render-affecting bump fails RED until the committed PNG is regenerated with `make diagrams`.",
+      "managerFilePatterns": ["/^docs/diagrams/.*\\.puml$/"],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "plantuml-stdlib/C4-PlantUML",
+      "matchStrings": ["raw\\.githubusercontent\\.com/plantuml-stdlib/C4-PlantUML/(?<currentValue>v[0-9.]+)/"]
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Closes a durability gap left by the diagram migration (#333): the C4-PlantUML `!include` version (`v2.11.0`) in `docs/diagrams/c4-context.puml` was the one tool pin in the repo Renovate didn't track.

## Changes
- **renovate.json**: add a regex customManager (`datasource=github-tags`, `depName=plantuml-stdlib/C4-PlantUML`) matching the `v<ver>` segment of the raw.githubusercontent `!include` URL in `docs/diagrams/*.puml`. A bump changes the `.puml`, which the `code` paths-filter routes to `static-check` → `diagrams-check` (drift gate) — so a render-affecting bump fails RED until the PNG is regenerated. Tracking + drift gate compose correctly.
- **CLAUDE.md**: bump Upgrade Backlog `Last reviewed` to 2026-06-30.

## Verification
- `make renovate-validate` → rc=0 (config valid).
- Regex tested against the `.puml`: captures `v2.11.0` (the manager tracks a real value, not nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)