### PR TITLE
ci(diagrams): auto-regenerate committed PNGs on render-affecting Renovate bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     tags: ["v*"]
   pull_request:
   workflow_call:
+  # Re-fired by diagram-regen.yml after it commits a regenerated PNG back to a
+  # Renovate PR: a GITHUB_TOKEN push doesn't trigger `pull_request` (anti-recursion),
+  # so the new head SHA needs an explicit dispatch to produce the `ci-pass` check.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,11 +29,15 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      code: ${{ startsWith(github.ref, 'refs/tags/') && 'true' || steps.filter.outputs.code }}
+      # Tag pushes and workflow_dispatch (the diagram-regen re-fire) always run
+      # the full gate: a dispatch has no diff base for paths-filter, and it only
+      # ever fires after a render-affecting commit, so force code=true.
+      code: ${{ (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') && 'true' || steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - id: filter
+        if: github.event_name != 'workflow_dispatch'
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           base: ${{ github.event_name == 'push' && 'main' || '' }}

--- a/.github/workflows/diagram-regen.yml
+++ b/.github/workflows/diagram-regen.yml
@@ -1,0 +1,90 @@
+# Auto-regenerate committed PlantUML PNGs on Renovate PRs that bump a
+# render-affecting version (the C4-PlantUML `!include` in docs/diagrams/*.puml,
+# or PLANTUML_VERSION in the Makefile). Renovate (Mend Cloud) cannot run
+# `make diagrams`, so without this every such bump opens a PR that `diagrams-check`
+# fails on forever (the committed PNG drifts from the bumped source) and never
+# automerges. This workflow renders the PNG, commits it back to the PR head, and
+# re-fires the gating `ci.yml` on the new SHA so the PR can go green + automerge,
+# hands-off. See /architecture-diagrams + /renovate "customManager whose bump
+# drives a committed-artifact regen" and /ci-workflow
+# "GITHUB_TOKEN anti-recursion + the regen-and-commit-back pattern".
+name: diagram-regen
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/diagrams/**/*.puml"
+      - "Makefile" # carries PLANTUML_VERSION (a bump forces a re-render via the stamp)
+
+permissions:
+  contents: write # push the regenerated PNG to the PR branch
+  actions: write # gh workflow run (re-fire ci.yml) — NOT pull-requests: write
+
+concurrency:
+  group: diagram-regen-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  regen:
+    # Only Renovate's own PRs. A fork PR gets a read-only GITHUB_TOKEN anyway
+    # (so the push would fail harmlessly), but the author gate makes the scope
+    # explicit and keeps the privileged push off every non-bot PR.
+    if: github.event.pull_request.user.login == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 2
+
+      # Recursion guard: belt-and-suspenders. A GITHUB_TOKEN push does NOT fire
+      # `pull_request` (anti-recursion), so this workflow won't re-trigger itself
+      # — but if the push credential is ever swapped for a PAT/App token, this
+      # stops an infinite regen loop. Skip when the tip is already our own commit.
+      - id: guard
+        run: |
+          last_author=$(git log -1 --format='%an')
+          if [ "$last_author" = "github-actions[bot]" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # `make diagrams` renders via the pinned plantuml/plantuml Docker image
+      # (PLANTUML_VERSION in the Makefile) — the same renderer ci.yml uses, so
+      # the output is byte-identical to what diagrams-check expects.
+      - name: Regenerate diagrams
+        if: steps.guard.outputs.skip != 'true'
+        run: make diagrams
+
+      - name: Detect drift
+        if: steps.guard.outputs.skip != 'true'
+        id: drift
+        run: |
+          if git diff --quiet -- docs/diagrams/out; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit + push regenerated PNG and re-trigger CI
+        if: steps.guard.outputs.skip != 'true' && steps.drift.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add docs/diagrams/out
+          git commit -m "chore(diagrams): regenerate rendered PNGs for the bumped renderer/stdlib"
+          git push origin "HEAD:${PR_HEAD_REF}"
+          # The GITHUB_TOKEN push above will NOT trigger ci.yml (anti-recursion).
+          # workflow_dispatch IS in the exception list, so explicitly re-fire the
+          # gate on the new head SHA — this produces the `ci-pass` required check
+          # the ruleset needs before Renovate can automerge.
+          gh workflow run ci.yml --ref "${PR_HEAD_REF}"


### PR DESCRIPTION
## Problem (root cause of recurring failing Renovate PRs)

The C4-PlantUML \`!include\` version in \`docs/diagrams/*.puml\` and \`PLANTUML_VERSION\` in the Makefile are Renovate-tracked (added in #336). But **Renovate (Mend Cloud) cannot run \`make diagrams\`** — it bumps the *source* and never regenerates the committed PNG. So every such bump opens a PR where the committed \`docs/diagrams/out/c4-context.png\` drifts from source, \`diagrams-check\` correctly fails, and — with \`automerge: true\` — the PR **sits perpetually RED and never merges** until a human runs \`make diagrams\` + commits by hand.

This just bit PR #337 (C4-PlantUML v2.11.0 → v2.13.0); I fixed that PR's PNG manually. This change makes it self-healing so it never recurs.

## Fix

**\`diagram-regen.yml\` (new):** on a \`renovate[bot]\` PR touching \`docs/diagrams/**/*.puml\` or \`Makefile\`:
1. \`make diagrams\` (pinned \`plantuml/plantuml\` Docker image — same renderer CI uses, byte-identical output)
2. if the PNG drifted, commit it back to the PR head
3. \`gh workflow run ci.yml --ref <branch>\` — a GITHUB_TOKEN push does **not** trigger \`pull_request\` (anti-recursion), so the new head SHA needs an explicit \`workflow_dispatch\` to produce the \`ci-pass\` required check

The bump PR then renders → commits → goes green → automerges, hands-off.

**\`ci.yml\`:** adds the \`workflow_dispatch\` trigger and forces \`changes.code=true\` on dispatch (a dispatch has no diff base for paths-filter and only ever fires after a render-affecting commit).

## Security

- \`pull_request\` (NOT \`pull_request_target\`); scoped to \`github.event.pull_request.user.login == 'renovate[bot]'\`. Fork PRs get a read-only GITHUB_TOKEN so the push would fail harmlessly regardless.
- Permissions: \`contents: write\` (push) + \`actions: write\` (dispatch). No \`pull-requests: write\`, no \`packages: write\`.
- Recursion guard skips when the branch tip is already \`github-actions[bot]\` (belt-and-suspenders for any future PAT/App-token swap).
- No new secret required (uses GITHUB_TOKEN + workflow_dispatch).

## Verification

- \`actionlint\` clean on \`diagram-regen.yml\` and the \`ci.yml\` edits (only pre-existing info-level SC2086 in the DAST job remain).
- YAML parses.
- **Known gap (honest):** the end-to-end self-heal (regen → commit-back → dispatch → green → automerge) cannot be exercised until the *next* real render-affecting Renovate bump lands after this is on \`main\` (\`workflow_dispatch\` must be on the default branch first). The logic + permissions follow the verified \`/ci-workflow\` regen-and-commit-back pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)