### PR TITLE
ci(diagrams): add regen-diagrams label trigger (manual force-regen escape hatch)

### DIFF
--- a/.github/workflows/diagram-regen.yml
+++ b/.github/workflows/diagram-regen.yml
@@ -12,7 +12,7 @@ name: diagram-regen
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - "docs/diagrams/**/*.puml"
       - "Makefile" # carries PLANTUML_VERSION (a bump forces a re-render via the stamp)
@@ -27,10 +27,16 @@ concurrency:
 
 jobs:
   regen:
-    # Only Renovate's own PRs. A fork PR gets a read-only GITHUB_TOKEN anyway
-    # (so the push would fail harmlessly), but the author gate makes the scope
-    # explicit and keeps the privileged push off every non-bot PR.
-    if: github.event.pull_request.user.login == 'renovate[bot]'
+    # Renovate's own bump PRs (the automated path), OR any PR a maintainer
+    # labels `regen-diagrams` (a manual "force-regenerate the committed PNGs"
+    # button — only write-access users can apply labels, so no added attack
+    # surface). A fork PR gets a read-only GITHUB_TOKEN anyway (the push would
+    # fail harmlessly), and the `labeled` path still requires the PR diff to
+    # touch a diagram source (the `paths:` filter above), so labeling a
+    # non-diagram PR is a no-op.
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'regen-diagrams')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
Adds a `labeled` trigger + `regen-diagrams` label condition to `diagram-regen.yml` so a maintainer can force a committed-PNG regeneration on any diagram-source PR (only write-access users can apply labels — no added attack surface; the `paths:` filter still requires the PR to touch a diagram source).

Two purposes: (1) a manual recovery button if a render-affecting PR ever gets stuck; (2) makes the commit-back self-heal chain exercisable on a controlled test PR rather than waiting for a live Renovate bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)