### PR TITLE
ci+docs: harden report uploads vs transient artifact 403; fix stale README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,9 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
+        # Diagnostic artifact, not a gate — a transient artifact-service 403/5xx
+        # on upload must not red an otherwise-green run.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
@@ -427,6 +430,9 @@ jobs:
 
       - name: Upload DAST report
         if: always()
+        # Diagnostic artifact, not a gate — a transient artifact-service 403/5xx
+        # on upload must not red an otherwise-green run.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zap-baseline-report
@@ -462,6 +468,10 @@ jobs:
 
       - name: Upload Lighthouse report
         if: ${{ !cancelled() }}
+        # Diagnostic artifact, not a gate — a transient artifact-service 403/5xx
+        # on upload must not red an otherwise-green run (observed 2026-06-30:
+        # the Lighthouse budgets passed but FinalizeArtifact 403'd and red'd main).
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: lighthouse-report

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ GitHub Actions runs on every push to `main`, tags `v*`, pull requests, and `work
 | **dast**         | code change    | Build → start → ZAP baseline (fail-on-warn; `.zap/baseline-rules.tsv` ignores informational rules) → upload report |
 | **ci-pass**      | all            | Aggregation gate (`if: always()`) — single required check for branch protection                 |
 
+A [diagram-regen workflow](.github/workflows/diagram-regen.yml) regenerates the committed C4 PNG on a render-affecting Renovate bump (the C4-PlantUML `!include` version or `PLANTUML_VERSION`) or on demand via the `regen-diagrams` label — because Renovate can't run `make diagrams` itself. It commits the corrected PNG back; the merge is finished manually (the Repository Ruleset blocks the bot's commit-back CI).
+
 A weekly [cleanup workflow](.github/workflows/cleanup-runs.yml) deletes workflow runs older than 7 days (keeping a minimum of 5).
 
 Docker images are pushed to `ghcr.io` as multi-arch (`linux/amd64` + `linux/arm64`) with GHA build cache.
@@ -229,4 +231,4 @@ cosign verify ghcr.io/andriykalashnykov/viteapp:<tag> \
 
 No additional secrets are required. The workflow uses only `GITHUB_TOKEN` (auto-provided by GitHub Actions) for GHCR login and OIDC token minting (cosign keyless signing).
 
-[Renovate](https://docs.renovatebot.com/) keeps dependencies up to date with platform automerge enabled.
+[Renovate](https://docs.renovatebot.com/) keeps dependencies up to date and merges them via PR automerge once the `ci-pass` check passes (`automergeType: pr`; platform automerge is disabled to avoid the native auto-merge registration race that can merge a red bump before the check registers).


### PR DESCRIPTION
Closes out left-out items found while auditing the diagram-regen work.

**1. main went red on a transient artifact 403 (not a real regression).** The post-merge run of #343 failed `lighthouse` — but the step `Lighthouse CI (budgets): success`; only `Upload Lighthouse report` failed with `FinalizeArtifact … 403 Forbidden` (a GitHub artifact-service hiccup). Re-running cleared it. Durable fix: `continue-on-error: true` on the lighthouse/playwright/dast **report-upload** steps — they're diagnostic artifacts, not gates (the real assertions run in prior steps and still fail the job on a real regression).

**2. Stale README (self-review-bias guard).**
- "platform automerge enabled" was factually wrong — the project uses `automergeType: pr` + `platformAutomerge: false`. Corrected.
- Added the `diagram-regen.yml` workflow to the README's workflow docs (it documented the sibling `cleanup-runs` but not this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)