### PR TITLE
fix(makefile): pre-clean root-owned zap-output before dast rerun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,7 @@ dast: image-build
 			curl -fsS http://localhost:8080/internal/isalive >/dev/null 2>&1 && break; \
 			sleep 1; \
 		done
+	@rm -rf zap-output 2>/dev/null || docker run --rm --user 0 -v "$(PWD):/work" -w /work --entrypoint rm ghcr.io/zaproxy/zaproxy:$(ZAP_VERSION) -rf zap-output
 	@mkdir -p zap-output && chmod 777 zap-output
 	@echo "DAST report will be written to: $(PWD)/zap-output/zap-report.html"
 	@docker run --rm --network host \


### PR DESCRIPTION
## What

Fix a Makefile run-safeguard gap in the `dast` target (/makefile Safety
Check #17 — root-owned bind-mount output).

The `dast` recipe runs `ghcr.io/zaproxy/zaproxy` with a
`-v $(PWD)/zap-output:/zap/wrk` bind mount and **no `--user`**, so ZAP
writes its report files into `zap-output` as **root**. On the next run
the root-owned directory makes `chmod 777 zap-output` fail with
`Operation not permitted`, and also breaks `make clean`'s
`rm -rf ... zap-output`.

## Change

One line added immediately before the `mkdir -p zap-output && chmod 777`
line — a root-capable pre-clean:

```make
@rm -rf zap-output 2>/dev/null || docker run --rm --user 0 -v "$(PWD):/work" -w /work --entrypoint rm ghcr.io/zaproxy/zaproxy:$(ZAP_VERSION) -rf zap-output
```

The `--user 0` docker fallback handles the case where a plain user `rm`
can't remove a root-owned tree (the zaproxy image runs as non-root
uid 1000, so the fallback must force uid 0). Style matches the repo:
`$(PWD)`, `$(ZAP_VERSION)`, tab-indented `@` recipe line.

Scope kept minimal (Makefile-only; no diagram/workflow changes). CI's
inline DAST in `ci.yml` uses a fresh `GITHUB_WORKSPACE` per run and is
unaffected; there is no sibling `dast-scan` Makefile target.

## Verification

- `make -n dast` parses cleanly with the pre-clean line first.
- RED→GREEN proven locally: simulated a Docker-created root-owned
  `zap-output` (mode 755, uid 0) → `chmod 777` failed
  `Operation not permitted` (RED); ran the fix's pre-clean line → dir
  removed → `mkdir -p && chmod 777` then succeeded (GREEN). Cleaned up.
